### PR TITLE
fix(proxy): fixed proxy

### DIFF
--- a/bin/anywhere
+++ b/bin/anywhere
@@ -111,8 +111,6 @@ if (argv.fallback !== undefined) {
     index: argv.fallback || '/index.html'
   }));
 }
-app.use(serveStatic(argv.dir, { 'index': ['index.html'] }));
-app.use(serveIndex(argv.dir, { 'icons': true }));
 
 // anywhere --proxy webpack.config.js
 // anywhere --proxy proxy.config.js
@@ -140,6 +138,10 @@ if (argv.proxy) {
     });
   }
 }
+
+app.use(serveStatic(argv.dir, { 'index': ['index.html'] }));
+app.use(serveIndex(argv.dir, { 'icons': true }));
+
 
 // anywhere 8888
 // anywhere -p 8989


### PR DESCRIPTION
Using the old proxy method, a 405 error occurs when the request method is POST. Now, the proxy middleware is placed in front to solve this issue.